### PR TITLE
Show a confirmation message when quitting with unsaved changes

### DIFF
--- a/AccountManagerApp/Models/Messages.cs
+++ b/AccountManagerApp/Models/Messages.cs
@@ -15,5 +15,11 @@
         /// </summary>
         public const string FailedToLoadAccounts = "Failed to load accounts.";
 
+        /// <summary>
+        /// 未保存の変更がある場合の終了確認。
+        /// </summary>
+        public const string ConfirmToQuitWhenHavingUnsavedChanges = "There are some unsaved changes.\n"
+            + "Do you really want to quit without saving your changes?";
+
     }
 }

--- a/AccountManagerApp/Models/WindowManager.cs
+++ b/AccountManagerApp/Models/WindowManager.cs
@@ -47,5 +47,18 @@
         /// </remarks>
         void ShowError(ViewModel viewModel, string message);
 
+        /// <summary>
+        /// 確認メッセージを表示する。
+        /// </summary>
+        /// <param name="viewModel">確認メッセージを表示するビューモデル(null指定可)</param>
+        /// <param name="message">確認メッセージ(null指定不可)</param>
+        /// <returns>返答がOKだった場合はtrue、それ以外の場合はfalse</returns>
+        /// <remarks>
+        /// <para>このメソッドは確認メッセージが返答されるまで制御を返さない。</para>
+        /// <para><paramref name="viewModel"/>に関連付いたウィンドウが無い場合は何もしない。</para>
+        /// <para><paramref name="viewModel"/>にnullを指定した場合は親ウィンドウ無しでメッセージを表示する。</para>
+        /// </remarks>
+        bool ShowConfirmation(ViewModel viewModel, string message);
+
     }
 }

--- a/AccountManagerApp/Models/WindowManagerImpl.cs
+++ b/AccountManagerApp/Models/WindowManagerImpl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows;
 
 namespace AccountManagerApp
@@ -64,6 +65,7 @@ namespace AccountManagerApp
 
         private void ShowWindow(Window window, ViewModel viewModel)
         {
+            window.Closing += Window_Closing;
             window.Closed += Window_Closed;
             window.DataContext = viewModel;
 
@@ -74,6 +76,7 @@ namespace AccountManagerApp
 
         private void ShowDialog(Window window, ViewModel viewModel, ViewModel parentViewModel)
         {
+            window.Closing += Window_Closing;
             window.Closed += Window_Closed;
             window.DataContext = viewModel;
 
@@ -102,11 +105,28 @@ namespace AccountManagerApp
             }
         }
 
+        private void Window_Closing(object sender, CancelEventArgs e)
+        {
+            Window window = (Window)sender;
+            ViewModel viewModel = (ViewModel)window.DataContext;
+
+            if (_windowMap.ContainsKey(viewModel))
+            {
+                bool allowClose = viewModel.OnWindowClosing();
+
+                if (!allowClose)
+                {
+                    e.Cancel = true;
+                }
+            }
+        }
+
         private void Window_Closed(object sender, EventArgs e)
         {
             Window window = (Window)sender;
             ViewModel viewModel = (ViewModel)window.DataContext;
 
+            window.Closing -= Window_Closing;
             window.Closed -= Window_Closed;
 
             if (_windowMap.ContainsKey(viewModel))

--- a/AccountManagerApp/Models/WindowManagerImpl.cs
+++ b/AccountManagerApp/Models/WindowManagerImpl.cs
@@ -154,5 +154,37 @@ namespace AccountManagerApp
             }
         }
 
+        /// <summary>
+        /// <see cref="WindowManager.ShowConfirmation(ViewModel, string)"/>の実装。
+        /// </summary>
+        public bool ShowConfirmation(ViewModel viewModel, string message)
+        {
+            Utilities.RejectNull(message, nameof(message));
+
+            bool isOk = false;
+
+            if (viewModel == null)
+            {
+                MessageBoxResult messageBoxResult = MessageBox.Show(message, MessageBoxTitle, MessageBoxButton.OKCancel, MessageBoxImage.Question);
+
+                if (messageBoxResult == MessageBoxResult.OK)
+                {
+                    isOk = true;
+                }
+            }
+            else if (_windowMap.ContainsKey(viewModel))
+            {
+                Window window = _windowMap[viewModel];
+                MessageBoxResult messageBoxResult = MessageBox.Show(window, message, MessageBoxTitle, MessageBoxButton.OKCancel, MessageBoxImage.Question);
+
+                if (messageBoxResult == MessageBoxResult.OK)
+                {
+                    isOk = true;
+                }
+            }
+
+            return isOk;
+        }
+
     }
 }

--- a/AccountManagerApp/ViewModels/AccountWindowViewModel.cs
+++ b/AccountManagerApp/ViewModels/AccountWindowViewModel.cs
@@ -148,6 +148,14 @@ namespace AccountManagerApp
         }
 
         /// <summary>
+        /// <see cref="ViewModel.OnWindowClosing"/>の実装。
+        /// </summary>
+        public bool OnWindowClosing()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// <see cref="ViewModel.OnWindowClosed"/>の実装。
         /// </summary>
         public void OnWindowClosed()

--- a/AccountManagerApp/ViewModels/MainWindowViewModel.cs
+++ b/AccountManagerApp/ViewModels/MainWindowViewModel.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 
-// TODO: 未保存の変更がある状態でウィンドウを閉じようとした場合に確認メッセージを表示する。
-
 namespace AccountManagerApp
 {
     /// <summary>
@@ -208,7 +206,17 @@ namespace AccountManagerApp
         /// </summary>
         public bool OnWindowClosing()
         {
-            return true;
+            bool allowClose = true;
+
+            if (HasUnsavedChanges)
+            {
+                if (!_windowManager.ShowConfirmation(this, Messages.ConfirmToQuitWhenHavingUnsavedChanges))
+                {
+                    allowClose = false;
+                }
+            }
+
+            return allowClose;
         }
 
         /// <summary>

--- a/AccountManagerApp/ViewModels/MainWindowViewModel.cs
+++ b/AccountManagerApp/ViewModels/MainWindowViewModel.cs
@@ -204,6 +204,14 @@ namespace AccountManagerApp
         }
 
         /// <summary>
+        /// <see cref="ViewModel.OnWindowClosing"/>の実装。
+        /// </summary>
+        public bool OnWindowClosing()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// <see cref="ViewModel.OnWindowClosed"/>の実装。
         /// </summary>
         public void OnWindowClosed()

--- a/AccountManagerApp/ViewModels/ViewModel.cs
+++ b/AccountManagerApp/ViewModels/ViewModel.cs
@@ -6,6 +6,12 @@
     public interface ViewModel
     {
         /// <summary>
+        /// ウィンドウが閉じられようとしている際に呼び出される。
+        /// </summary>
+        /// <returns>ウィンドウを閉じてよい場合はtrue、閉じてはいけない場合はfalse</returns>
+        bool OnWindowClosing();
+
+        /// <summary>
         /// ウィンドウが閉じられた際に呼び出される。
         /// </summary>
         void OnWindowClosed();

--- a/AccountManagerAppTests/Mocks/WindowManagerMock.cs
+++ b/AccountManagerAppTests/Mocks/WindowManagerMock.cs
@@ -14,6 +14,11 @@
         public ViewModel ShowErrorParamViewModel { get; private set; }
         public string ShowErrorParamMessage { get; private set; }
 
+        public bool IsShowConfirmationCalled { get; private set; }
+        public ViewModel ShowConfirmationParamViewModel { get; private set; }
+        public string ShowConfirmationParamMessage { get; private set; }
+        public bool ShowConfirmationReturnValue { get; set; }
+
         public WindowManagerMock()
         {
             Clear();
@@ -32,6 +37,11 @@
             IsShowErrorCalled = false;
             ShowErrorParamViewModel = null;
             ShowErrorParamMessage = null;
+
+            IsShowConfirmationCalled = false;
+            ShowConfirmationParamViewModel = null;
+            ShowConfirmationParamMessage = null;
+            ShowConfirmationReturnValue = false;
         }
 
         public void ShowMainWindow(AccountManager accountManager)
@@ -60,6 +70,15 @@
             IsShowErrorCalled = true;
             ShowErrorParamViewModel = viewModel;
             ShowErrorParamMessage = message;
+        }
+
+        public bool ShowConfirmation(ViewModel viewModel, string message)
+        {
+            IsShowConfirmationCalled = true;
+            ShowConfirmationParamViewModel = viewModel;
+            ShowConfirmationParamMessage = message;
+
+            return ShowConfirmationReturnValue;
         }
 
     }

--- a/AccountManagerAppTests/Tests/MainWindowViewModelTests.cs
+++ b/AccountManagerAppTests/Tests/MainWindowViewModelTests.cs
@@ -498,5 +498,84 @@ namespace AccountManagerApp.Tests
             Assert.AreSame(account2, _accountManager.AccountList[0]);
         }
 
+        [TestMethod]
+        public void 未保存の変更がある場合にウィンドウを閉じようとすると確認メッセージが表示される()
+        {
+            Account account1 = new Account()
+            {
+                AccountName = "a",
+                UserId = "b",
+                Password = "c",
+                Url = "d",
+                Remarks = "e",
+            };
+
+            _accountManager.RegisterAccount(account1);
+            Assert.IsTrue(_mainWindowViewModel.HasUnsavedChanges);
+
+            bool allowClose = _mainWindowViewModel.OnWindowClosing();
+
+            Assert.IsTrue(_windowManager.IsShowConfirmationCalled);
+            Assert.AreSame(_mainWindowViewModel, _windowManager.ShowConfirmationParamViewModel);
+            Assert.AreEqual(Messages.ConfirmToQuitWhenHavingUnsavedChanges, _windowManager.ShowConfirmationParamMessage);
+        }
+
+        [TestMethod]
+        public void 未保存の変更が無い場合にウィンドウを閉じようとしても確認メッセージは表示されない()
+        {
+            Assert.IsFalse(_mainWindowViewModel.HasUnsavedChanges);
+
+            bool allowClose = _mainWindowViewModel.OnWindowClosing();
+
+            Assert.IsFalse(_windowManager.IsShowConfirmationCalled);
+            Assert.IsTrue(allowClose);
+        }
+
+        [TestMethod]
+        public void 未保存の変更がある場合にウィンドウを閉じようとした際の確認メッセージでOKを選択するとウィンドウが閉じる()
+        {
+            Account account1 = new Account()
+            {
+                AccountName = "a",
+                UserId = "b",
+                Password = "c",
+                Url = "d",
+                Remarks = "e",
+            };
+
+            _accountManager.RegisterAccount(account1);
+            Assert.IsTrue(_mainWindowViewModel.HasUnsavedChanges);
+
+            _windowManager.ShowConfirmationReturnValue = true;
+
+            bool allowClose = _mainWindowViewModel.OnWindowClosing();
+
+            Assert.IsTrue(_windowManager.IsShowConfirmationCalled);
+            Assert.IsTrue(allowClose);
+        }
+
+        [TestMethod]
+        public void 未保存の変更がある場合にウィンドウを閉じようとした際の確認メッセージでキャンセルを選択するとウィンドウは閉じない()
+        {
+            Account account1 = new Account()
+            {
+                AccountName = "a",
+                UserId = "b",
+                Password = "c",
+                Url = "d",
+                Remarks = "e",
+            };
+
+            _accountManager.RegisterAccount(account1);
+            Assert.IsTrue(_mainWindowViewModel.HasUnsavedChanges);
+
+            _windowManager.ShowConfirmationReturnValue = false;
+
+            bool allowClose = _mainWindowViewModel.OnWindowClosing();
+
+            Assert.IsTrue(_windowManager.IsShowConfirmationCalled);
+            Assert.IsFalse(allowClose);
+        }
+
     }
 }


### PR DESCRIPTION
Implemented the feature to show a confirmation message when the user tries to quit the app though there are unsaved changes.
If the user chooses 'cancel' then quitting will be canceled.